### PR TITLE
Expose emulator UI to external IPs.

### DIFF
--- a/emulate.py
+++ b/emulate.py
@@ -117,4 +117,4 @@ if __name__ == '__main__':
      flask_port = 50000
 
      print('For the UI, navigate a browser to localhost:' + str(flask_port))
-     app.run(use_reloader=False, port=flask_port)
+     app.run(use_reloader=False, host='0.0.0.0', port=flask_port)


### PR DESCRIPTION
By setting the host to 0.0.0.0 for Flask, you can access the UI from another computer.
