### PR TITLE
Update pip-requirements.txt

### DIFF
--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -2,6 +2,6 @@ Flask==0.10.1
 Jinja2==2.7
 MarkupSafe==0.18
 Werkzeug==0.9.2
-distribute==0.6.34
+distribute==0.7.3
 itsdangerous==0.22
 wsgiref==0.1.2


### PR DESCRIPTION
Needed to update the version for distribute since the old one is not available anymore. (e.g. "pip install -r pip-requirements.txt" will fail otherwise)