### PR TITLE
Update Package Requirements

### DIFF
--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -1,7 +1,5 @@
 Flask==1.0
 Jinja2==2.10.1
-MarkupSafe==0.18
+MarkupSafe==0.23
 Werkzeug==0.15.3
-distribute==0.7.3
-itsdangerous==0.22
-wsgiref==0.1.2
+itsdangerous==0.24


### PR DESCRIPTION
### Changes
- Update requirements to avoid `pip install` errors
    - Removed old/deprecated packages
    - Updated `MarkupSafe` -> 0.23
    - Updated `itsdangerous` -> 0.24

### Notes
Packages requirements were not updated fully when upgrading to Python 3. This resulted in some errors when pulling packages. The simulator would still run however it was misleading when errors would show up during the package install.